### PR TITLE
Images with relative width rendering

### DIFF
--- a/Classes/Resource/Rendering/ResponsiveImage.php
+++ b/Classes/Resource/Rendering/ResponsiveImage.php
@@ -176,7 +176,7 @@ class ResponsiveImage implements FileRendererInterface
             'width' => $width,
             'height' => $height,
             'crop' => $crop,
-            'additionalParameters' => $additionalParameters,
+            'additionalParameters' => $additionalParameters
         ];
 
         $processedImage = $imageService->applyProcessingInstructions($file, $processingInstructions);

--- a/Classes/Resource/Rendering/ResponsiveImage.php
+++ b/Classes/Resource/Rendering/ResponsiveImage.php
@@ -84,7 +84,7 @@ class ResponsiveImage implements FileRendererInterface
         if (!array_key_exists(self::OPTIONS_IMAGE_RELATVE_WIDTH_KEY, $options)
             && isset($GLOBALS['TSFE']->register[self::REGISTER_IMAGE_RELATVE_WIDTH_KEY])
         ) {
-            $options[self::OPTIONS_IMAGE_RELATVE_WIDTH_KEY] = $GLOBALS['TSFE']->register[self::REGISTER_IMAGE_RELATVE_WIDTH_KEY];
+            $options[self::OPTIONS_IMAGE_RELATVE_WIDTH_KEY] = (float) $GLOBALS['TSFE']->register[self::REGISTER_IMAGE_RELATVE_WIDTH_KEY];
         }
 
         // Check if a responsive image tag should be rendered. If not, just return the normal image tag.

--- a/Classes/Resource/Rendering/ResponsiveImage.php
+++ b/Classes/Resource/Rendering/ResponsiveImage.php
@@ -32,6 +32,9 @@ class ResponsiveImage implements FileRendererInterface
 {
     const DEFAULT_IMAGE_VARIANT_KEY = 'default';
     const REGISTER_IMAGE_VARIANT_KEY = 'IMAGE_VARIANT_KEY';
+    const REGISTER_IMAGE_RELATVE_WIDTH_KEY = 'IMAGE_RELATIVE_WIDTH_KEY';
+    const OPTIONS_IMAGE_RELATVE_WIDTH_KEY = 'relativeScalingWidth';
+
     /**
      * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface
      */
@@ -77,6 +80,12 @@ class ResponsiveImage implements FileRendererInterface
     public function render(FileInterface $file, $width, $height, array $options = [], $usedPathsRelativeToCurrentScript = false)
     {
         $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+
+        if (!array_key_exists(self::OPTIONS_IMAGE_RELATVE_WIDTH_KEY, $options)
+            && isset($GLOBALS['TSFE']->register[self::REGISTER_IMAGE_RELATVE_WIDTH_KEY])
+        ) {
+            $options[self::OPTIONS_IMAGE_RELATVE_WIDTH_KEY] = $GLOBALS['TSFE']->register[self::REGISTER_IMAGE_RELATVE_WIDTH_KEY];
+        }
 
         // Check if a responsive image tag should be rendered. If not, just return the normal image tag.
         if (isset($options['disablePictureTag']) && $options['disablePictureTag'] == true) {

--- a/Classes/Resource/Rendering/ResponsiveImage.php
+++ b/Classes/Resource/Rendering/ResponsiveImage.php
@@ -187,7 +187,9 @@ class ResponsiveImage implements FileRendererInterface
                 'width' => $processedImage->getProperty('width') * $relativeScalingWidth,
             ];
 
-            $processedImage = $imageService->applyProcessingInstructions($processedImage, $relativeScalingProcessingInstructions);
+            $scaleProcessedImage = $imageService->applyProcessingInstructions($processedImage, $relativeScalingProcessingInstructions);
+            $processedImage->delete(true);
+            return $scaleProcessedImage;
         }
 
         return $processedImage;

--- a/Classes/Resource/Rendering/ResponsiveImage.php
+++ b/Classes/Resource/Rendering/ResponsiveImage.php
@@ -184,7 +184,7 @@ class ResponsiveImage implements FileRendererInterface
         if ($relativeScalingWidth > 0) {
             $relativeScalingProcessingInstructions = [
                 'crop' => false,
-                'width' => $width * $relativeScalingWidth,
+                'width' => $processedImage->getProperty('width') * $relativeScalingWidth,
             ];
 
             $processedImage = $imageService->applyProcessingInstructions($processedImage, $relativeScalingProcessingInstructions);

--- a/Classes/Resource/Rendering/ResponsiveImage.php
+++ b/Classes/Resource/Rendering/ResponsiveImage.php
@@ -176,7 +176,7 @@ class ResponsiveImage implements FileRendererInterface
             'width' => $width,
             'height' => $height,
             'crop' => $crop,
-            'additionalParameters' => $additionalParameters
+            'additionalParameters' => $additionalParameters,
         ];
 
         $processedImage = $imageService->applyProcessingInstructions($file, $processingInstructions);
@@ -184,7 +184,7 @@ class ResponsiveImage implements FileRendererInterface
         if ($relativeScalingWidth > 0) {
             $relativeScalingProcessingInstructions = [
                 'crop' => false,
-                'width' => $width * $relativeScalingWidth
+                'width' => $width * $relativeScalingWidth,
             ];
 
             $processedImage = $imageService->applyProcessingInstructions($processedImage, $relativeScalingProcessingInstructions);


### PR DESCRIPTION
Sometimes images have some relative width and won't fill their container.

This new feature interferes the rendering task so that you can provide a relative width of the image and the processed image of a given `srcset` will be scaled afterwards.

Use the register key `IMAGE_RELATIVE_WIDTH_KEY` with float values from `>0.0` to `1.0`.
*NOTE:* The zero (`0.0`)  value means no scaling.