### PR TITLE
[!!!][Fix] Use read-only files for local processing

### DIFF
--- a/Classes/Resource/Service/ImageService.php
+++ b/Classes/Resource/Service/ImageService.php
@@ -40,7 +40,7 @@ class ImageService
     public function isAnimatedGif(FileInterface $file): bool
     {
         if ($file->getMimeType() === 'image/gif') {
-            $filecontents = file_get_contents($file->getForLocalProcessing());
+            $filecontents = file_get_contents($file->getForLocalProcessing(false));
             $strLoc = 0;
             $count = 0;
 


### PR DESCRIPTION
This prevents the `var/transient/` folder from cluttering up with `fal-tempfile-*.gif` files.
Important: You must manually clean up your files once. E.g. use `find var/transient/ -type f -name 'fal-tempfile-*.gif' -exec rm {} \;` 

For local drivers getForLocalProcessing(false) returns the absolute path of the original file.
Remote drivers download the file, but take care of cleaning it up by themselves.

Also see https://github.com/hausformat/exif_orientation_helper/commit/0d0373c8a8bfdfff1e718abb2c5a0582245d0cc9